### PR TITLE
Using a local openjdk8-openj9 image

### DIFF
--- a/experimental/java-microprofile-dev-mode/image/Dockerfile-stack
+++ b/experimental/java-microprofile-dev-mode/image/Dockerfile-stack
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk8-openj9
+FROM openjdk8-openj9-local
 
 USER root
 RUN  apt-get -qq update \

--- a/experimental/java-microprofile-dev-mode/image/project/Dockerfile
+++ b/experimental/java-microprofile-dev-mode/image/project/Dockerfile
@@ -1,7 +1,6 @@
-FROM adoptopenjdk/openjdk8-openj9
+FROM openjdk8-openj9-local
 
-RUN apt-get update && \
-    apt-get install -y maven unzip
+RUN apt-get install -y maven unzip
 
 # Pre-cache of maven dependencies
 COPY pom.xml /project/ 


### PR DESCRIPTION
This change is an optimization for Kabanero workshops  based on the java-microprofile-dev-mode collection.

It assumes the user has executed the [workshop-setup.sh script](https://github.com/gcharters/kabanero-dev-getting-started/blob/master/scripts/workshop-setup.sh) to build a new openjdk8-openj9-local docker image.

The new image is based on adoptopenjdk/openjdk8-openj9 (we can decide on publishing this new image to a docker.io repository and avoid the dependency on workshop-setup.sh)  .

The new openjdk8-openj9-local image contains apt-get update + maven + cached maven repositories, so it is larger than the original image (~600Mb instead of 400Mb) , but then it saves considerable volume of downloads in all subsequent builds by either Jane or Champ personas during Kabanero workshops.
