### PR TITLE
Use / cygdrive mount

### DIFF
--- a/ci/package.sh
+++ b/ci/package.sh
@@ -212,8 +212,13 @@ do
             fi
         done
 
+        ## Matches
+        # file:///cygdrive/c/Users/Blah
+        #  and
+        # file:///c/Users/Blah
+
         # For Cygwin support, harmless on other distros
-         [[ `uname` == CYGWIN* ]] && sed -i "s|/cygdrive/\([a-z]\)|/\1:|g" $index_file_local
+        [[ `uname` == CYGWIN* ]] && sed -i "s|file:\/\/\/\(cygdrive\/\)\{0,1\}\([a-z]\)|file:\/\/\/\2:|1" $index_file_local
     else
         echo "SKIPPING: $repo_dir"
     fi


### PR DESCRIPTION
I mount my cygwin install to `/`  not `/cygdrive/c` so this fix, while appreciated, doesn't quite work for me.

Here's a tweak of the 'sed' invcation that fixes it for both types of installs.   

I guess even better might be to externalize this mount point even further, (since I also had to adjust your https://github.com/gcharters/kabanero-dev-getting-started/blob/master/scripts/workshop-setup.sh script)...and/or I could open an issue if you'd rather have that than just the PR.